### PR TITLE
Add .env.sample + setup steps in README

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-POSTGRES_PRISMA_URL="postgresql://bitcoinlink:bitcoinlink@localhost:5432/bitcoinlink?schema=public"
+POSTGRES_PRISMA_URL="postgresql://bitcoinlink:bitcoinlink@bitcoinlink-db:5432/bitcoinlink?schema=public"
 POSTGRES_PASSWORD=bitcoinlink
 POSTGRES_USER=bitcoinlink
 POSTGRES_DB=bitcoinlink

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+POSTGRES_PRISMA_URL="postgresql://bitcoinlink:bitcoinlink@localhost:5432/bitcoinlink?schema=public"
+POSTGRES_PASSWORD=bitcoinlink
+POSTGRES_USER=bitcoinlink
+POSTGRES_DB=bitcoinlink

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ Made possible by Nostr Wallet Connect [(NWC)](https://nwc.dev)
 - Create multiple links from one NWC
 - Claim links 1 at a time non-custodially through api endpoint at `GET https://www.bitcoinlink.app/api/link/{nwcID}` providing the secret as your 'authorization' header
 - Redeem links with bolt11, lud16 lightning address, or lud06 LNURL
+
+## development
+
+```
+$ cp .env.sample env
+$ docker-compose up
+```


### PR DESCRIPTION
Hi Austin, I read your post about [the hack](https://stacker.news/items/577322) (sorry to hear that!) and realized that after pulling the repository, `docker-compose up` fails with this error:

```
.env: no such file or directory
```

I then realized it's not immediately clear which env vars are required. But afaict, it's only postgres env vars since I didn't find any usage of `process.env`.

I think it makes sense to include a sample env file so one does not have to guess.

This PR adds such a sample env file which one can copy to `.env` to fix the error. Then all one needs to do is to run `docker-compose run`. I also mentioned this in the README so it's clear that this is indeed all that is needed (?).

I'm also not sure if you need this line:

https://github.com/AustinKelsay/bitcoinlink/blob/31f64cd37de5fd232fed75a693c99c6250093a00/prisma/schema.prisma#L9

At least when I removed it I was able to run `npx prisma migrate dev`.